### PR TITLE
Enable configurable volume mounts

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -9,3 +9,8 @@ command=docker
 ; Make sure this is where your docker friendly sock is. 
 ; ie "/run/user/1000/podman/podman.sock"
 sock=/var/run/docker.sock
+
+[volumes]
+localai=/var/lib/docker/volumes/midoriai_midori-ai-models/_data:/build/models
+ollama=/var/lib/docker/volumes/midoriai_midori-ai-ollama/_data:/root/.ollama
+invokeai=/var/lib/docker/volumes/midoriai_midori-ai-invokeai/_data:/invokeai

--- a/invokeai.py
+++ b/invokeai.py
@@ -1,4 +1,5 @@
 
+from config import volumes
 from runcommand import run_commands_async
 
 async def invokeai(ui, manager, docker_run_command):
@@ -17,7 +18,7 @@ async def invokeai(ui, manager, docker_run_command):
 
     containerd_name = "ghcr.io/invoke-ai/invokeai"
 
-    mount_folders = "-v /var/lib/docker/volumes/midoriai_midori-ai-invokeai/_data:/invokeai"
+    mount_folders = f"-v {volumes['invokeai']}"
 
     docker_command = f"{manager.command_base} {docker_run_command} -d {mount_folders} -p {port_to_use}:9090"
 

--- a/localai.py
+++ b/localai.py
@@ -1,4 +1,5 @@
 
+from config import volumes
 from runcommand import run_commands_async
 
 async def localai(ui, manager, docker_run_command):
@@ -15,7 +16,7 @@ async def localai(ui, manager, docker_run_command):
     port_to_use = manager.port + local_port_offset
     full_image_name_command = f"--name {manager.image}"
 
-    mount_folders = "-v /var/lib/docker/volumes/midoriai_midori-ai-models/_data:/build/models"
+    mount_folders = f"-v {volumes['localai']}"
 
     docker_command = f"{manager.command_base} {docker_run_command} -d {mount_folders} -p {port_to_use}:8080"
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from config import docker_run_command
 from config import docker_run_rm_command
 
 from config import docker_sock_command
+from config import volumes, update_volume_config
 
 from manager import Manager_mode
 
@@ -127,6 +128,14 @@ with ui.splitter(reverse=True) as splitter:
 
             ui.label("Settings:")
             ui.input(label='Port Number', placeholder='Edit to change port', on_change=lambda e: manager.change_port(e.value))
+
+        with ui.row():
+            ui.label("Volume Mounts:")
+        with ui.column():
+            localai_box = ui.input(label='LocalAI', value=volumes['localai'])
+            ollama_box = ui.input(label='Ollama', value=volumes['ollama'])
+            invoke_box = ui.input(label='InvokeAI', value=volumes['invokeai'])
+            ui.button("Save Mounts", on_click=lambda: update_volume_config({'localai': localai_box.value, 'ollama': ollama_box.value, 'invokeai': invoke_box.value}))
 
         ui.separator()
 

--- a/ollama.py
+++ b/ollama.py
@@ -1,4 +1,5 @@
 
+from config import volumes
 from runcommand import run_commands_async
 
 async def ollama(ui, manager, docker_run_command):
@@ -15,7 +16,7 @@ async def ollama(ui, manager, docker_run_command):
     port_to_use = manager.port + local_port_offset
     full_image_name_command = f"--name {manager.image}"
 
-    mount_folders = "-v /var/lib/docker/volumes/midoriai_midori-ai-ollama/_data:/root/.ollama"
+    mount_folders = f"-v {volumes['ollama']}"
 
     docker_command = f"{manager.command_base} {docker_run_command} -d {mount_folders} -p {port_to_use}:11434"
 


### PR DESCRIPTION
## Summary
- add helper to persist volume mounts in `config.py`
- expose mount paths in `config.ini`
- use volume config in localai, ollama and invokeai backends
- add mount edit inputs in the main UI
- document how to adjust mounts via the interface
- strip `-v` from config values and prefix in code
- remove unused README section

## Testing
- `python -m py_compile config.py localai.py ollama.py invokeai.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_687419342dc0832ca9abc5dc13276f73