### PR TITLE
Add sunset notice and remove repository update check before UI launch

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 ## But I am hopeing that we can get this worked out, only remove these comments if we have done this and this is live
 
 import os
-import sys
 
 from nicegui import ui, app, native
 
@@ -18,8 +17,6 @@ from config import docker_sock_command
 from config import volumes, update_volume_config
 
 from manager import Manager_mode
-
-from update_repo import update_repo
 
 ### To add your own backends just import them here and format them like the others
 
@@ -37,8 +34,7 @@ from anythingllm import anythingllm
 
 temp_menu = False
 
-if update_repo():
-    sys.exit(0)
+# NOTE: This program is being sunset on 1/1/2026. Thank you for using it! - Midori AI and Luna
 
 def get_docker_json():
     temp_file = "docker_ps_output.md"


### PR DESCRIPTION
## Summary
- remove the update_repo import from the application entry point
- skip the pre-launch repository update check so the UI starts immediately
- add a sunset notice comment for the subsystem manager scheduled for 1/1/2026

## Testing
- uv run python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694dd1840488832c86401e57b6527824)